### PR TITLE
Backward compatibility support to asn1 "a" for type :ipv4address needed in snmp get/set commands to Brocade/Foundry ICX Switches

### DIFF
--- a/lib/snmp_mib.ex
+++ b/lib/snmp_mib.ex
@@ -8,7 +8,7 @@ defmodule SNMPMIB do
   Provides SNMP object struct and supporting functions.
   """
 
-  @type asn1_tag :: 0 | 1..6 | 9..10
+  @type asn1_tag :: 0 | 1..6 | 9..11
   @type asn1_type ::
       :any
     | :boolean
@@ -20,6 +20,8 @@ defmodule SNMPMIB do
     | :object_identifier
     | :real
     | :enumerated
+    | :ipaddress # deprecared type obsoleted by RFC2851 - maps to asn1 "s" instead of "a" now
+    | :ipv4address # required for backwards compatibility to map to asn1 "a" e.g. Brocade Foundry/ICX switches
 
   defmodule Object do
     @moduledoc """
@@ -33,7 +35,7 @@ defmodule SNMPMIB do
       type: SNMPMIB.asn1_tag,
       value: String.t | number
     }
-    
+
     @doc """
     Returns OID of `object`.
     """
@@ -61,7 +63,7 @@ defmodule SNMPMIB do
     def type(object, new_type) when is_atom new_type do
       %Object{object | type: new_type}
     end
-    
+
     @doc """
     Returns value of `object`.
     """
@@ -142,7 +144,8 @@ defmodule SNMPMIB do
       5 => "=",
       6 => "o",
       9 => "d",
-      10 => "i"
+      10 => "i",
+      11 => "a" # backwards compatibility to asn1 "a" type :ipv4address type used by Brocade Foundry/ICX Switches
     } |> Map.fetch!(type)
   end
 
@@ -159,7 +162,8 @@ defmodule SNMPMIB do
       null: 5,
       object_identifier: 6, oid: 6,
       real: 9,
-      enumerated: 10
+      enuggmerated: 10,
+      ipv4address: 11 # backwards compatibility to asn1 "a" type :ipv4address type used by Brocade Foundry/ICX Switches
     } |> Map.fetch!(type)
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -26,7 +26,9 @@ defmodule SNMPMIB.Mixfile do
   end
 
   defp deps do
-    [ {:ex_doc, "~> 0.15", only: :dev}
+    [ {:ex_doc, "~> 0.15", only: :dev},
+      {:credo, "~> 0.7", only: [:dev, :test]},
+      {:dialyxir, "~> 0.4", only: [:dev, :test]}
     ]
   end
 end

--- a/mix.lock
+++ b/mix.lock
@@ -1,2 +1,5 @@
-%{"earmark": {:hex, :earmark, "1.1.1", "433136b7f2e99cde88b745b3a0cfc3fbc81fe58b918a09b40fce7f00db4d8187", [:mix], []},
-  "ex_doc": {:hex, :ex_doc, "0.15.0", "e73333785eef3488cf9144a6e847d3d647e67d02bd6fdac500687854dd5c599f", [:mix], [{:earmark, "~> 1.1", [hex: :earmark, optional: false]}]}}
+%{"bunt": {:hex, :bunt, "0.2.0", "951c6e801e8b1d2cbe58ebbd3e616a869061ddadcc4863d0a2182541acae9a38", [:mix], [], "hexpm"},
+  "credo": {:hex, :credo, "0.7.3", "9827ab04002186af1aec014a811839a06f72aaae6cd5eed3919b248c8767dbf3", [:mix], [{:bunt, "~> 0.2.0", [hex: :bunt, repo: "hexpm", optional: false]}], "hexpm"},
+  "dialyxir": {:hex, :dialyxir, "0.5.0", "5bc543f9c28ecd51b99cc1a685a3c2a1a93216990347f259406a910cf048d1d7", [:mix], [], "hexpm"},
+  "earmark": {:hex, :earmark, "1.2.0", "bf1ce17aea43ab62f6943b97bd6e3dc032ce45d4f787504e3adf738e54b42f3a", [:mix], [], "hexpm"},
+  "ex_doc": {:hex, :ex_doc, "0.15.1", "d5f9d588fd802152516fccfdb96d6073753f77314fcfee892b15b6724ca0d596", [:mix], [{:earmark, "~> 1.1", [hex: :earmark, repo: "hexpm", optional: false]}], "hexpm"}}


### PR DESCRIPTION
In our existing Brocade/Foundry ICX switches, we still require to pass in asn1 "a" tag for :ipaddress type. In order to not conflict with existing deprecated :ipaddress type, we are adding type as :ipv4address to provide asn1_tag "a" mapping when :ipv4address type is passed in for SNMPObject struct creation.

E.g. commands that rely on asn1 "a" :ipaddress type in Brocade/Foundry switches:
```
snmpget -v2c -c pub_community_string switch_ip_addr 1.3.6.1.4.1.1991.1.1.2.1.5.0 a tftp_server_ip_addr 
```
```
snmpset -v2c -c priv_community_string switch_ip_addr 1.3.6.1.4.1.1991.1.1.2.1.5.0 a tftp_server_ip_addr 1.3.6.1.4.1.1991.1.1.2.1.8.0 s running_config_file_name 1.3.6.1.4.1.1991.1.1.2.1.9.0 integer cmd_type
```

Reference: [Brocade Using SNMP to save and load configuration information](http://www.brocade.com/content/html/en/administration-guide/FI_08030_ADMIN/GUID-44BC46D0-6094-4E87-A1FD-9A57F17330CA.html)